### PR TITLE
Bump Less.rb dep version to v2.3.0

### DIFF
--- a/sprockets-less.gemspec
+++ b/sprockets-less.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
-  s.add_dependency 'less', '~> 2.2.0'
+  s.add_dependency 'less', '~> 2.3.0'
   s.add_dependency 'tilt', '~> 1.1'
   s.add_development_dependency 'sprockets-helpers', '~> 0.6'
   s.add_development_dependency 'rspec',             '~> 2.6'


### PR DESCRIPTION
Make the gem work with latest version of https://github.com/cowboyd/less.rb that was just recently updated to work with [Less 1.3.3](https://github.com/cloudhead/less.js/blob/master/CHANGELOG.md#133)
