### PR TITLE
support for middleman-sprockets

### DIFF
--- a/lib/sprockets/less.rb
+++ b/lib/sprockets/less.rb
@@ -1,6 +1,6 @@
+require 'sprockets'
 require 'sprockets/less/version'
 require 'sprockets/less/template'
-require 'sprockets/engines'
 
 module Sprockets
   module Less


### PR DESCRIPTION
sprockets-less didn't work in Middleman project with middleman-sprockets. This patch fixes it.

```
/home/nowaker/.rvm/gems/ruby-2.1.2/gems/sprockets-less-0.6.0/lib/sprockets/less.rb:23:in `<module:Sprockets>': undefined method `register_engine' for Sprockets:Module (NoMethodError)
        from /home/nowaker/.rvm/gems/ruby-2.1.2/gems/sprockets-less-0.6.0/lib/sprockets/less.rb:5:in `<top (required)>'
        from /home/nowaker/.rvm/gems/ruby-2.1.2/gems/sprockets-less-0.6.0/lib/sprockets-less.rb:1:in `require'
        from /home/nowaker/.rvm/gems/ruby-2.1.2/gems/sprockets-less-0.6.0/lib/sprockets-less.rb:1:in `<top (required)>'
        from /home/nowaker/.rvm/gems/ruby-2.1.2@global/gems/bundler-1.6.2/lib/bundler/runtime.rb:76:in `require'
        from /home/nowaker/.rvm/gems/ruby-2.1.2@global/gems/bundler-1.6.2/lib/bundler/runtime.rb:76:in `block (2 levels) in require'
        from /home/nowaker/.rvm/gems/ruby-2.1.2@global/gems/bundler-1.6.2/lib/bundler/runtime.rb:72:in `each'
        from /home/nowaker/.rvm/gems/ruby-2.1.2@global/gems/bundler-1.6.2/lib/bundler/runtime.rb:72:in `block in require'
        from /home/nowaker/.rvm/gems/ruby-2.1.2@global/gems/bundler-1.6.2/lib/bundler/runtime.rb:61:in `each'
        from /home/nowaker/.rvm/gems/ruby-2.1.2@global/gems/bundler-1.6.2/lib/bundler/runtime.rb:61:in `require'
        from /home/nowaker/.rvm/gems/ruby-2.1.2@global/gems/bundler-1.6.2/lib/bundler.rb:132:in `require'
        from /home/nowaker/.rvm/gems/ruby-2.1.2/gems/middleman-core-3.3.3/lib/middleman-core/load_paths.rb:37:in `setup_load_paths'
        from /home/nowaker/.rvm/gems/ruby-2.1.2/gems/middleman-core-3.3.3/bin/middleman:10:in `<top (required)>'
        from /home/nowaker/.rvm/gems/ruby-2.1.2/bin/middleman:23:in `load'
        from /home/nowaker/.rvm/gems/ruby-2.1.2/bin/middleman:23:in `<main>'
        from /home/nowaker/.rvm/gems/ruby-2.1.2/bin/ruby_executable_hooks:15:in `eval'
        from /home/nowaker/.rvm/gems/ruby-2.1.2/bin/ruby_executable_hooks:15:in `<main>'
```
